### PR TITLE
Fix QueryObject.hasRelations() - Add test for QueryObject.hasRelations() - Fix npm run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "files": [
       "tests/**/*"
     ],
-    "compileEnhancements": false,
     "extensions": [
       "ts"
     ],

--- a/src/QueryObject.ts
+++ b/src/QueryObject.ts
@@ -21,9 +21,9 @@ export class QueryObject {
      * Check if object has relations
      */
     public hasRelations() {
-        return this.relations.keys() !== 0
+        return Object.keys(this.relations).length !== 0
     }
-    
+
     /**
      * Checks if object has specified relation
      */

--- a/tests/QueryObjectTests.ts
+++ b/tests/QueryObjectTests.ts
@@ -17,3 +17,8 @@ test('test expandToGraph', async (t) => {
 
   t.deepEqual(graph[0].category, { 'name': 'test' })
 })
+
+test('test hasRelations', async (t) => {
+  const query = getQueryObject(info)
+  t.deepEqual(query.hasRelations(), true)
+})


### PR DESCRIPTION
There appears to be a bug in QueryObject.hasRelations. With no change to the code, and the addition of the hasRelations test I was getting the following error:
```
  1 test failed

  test hasRelations

  src\QueryObject.ts:24

   23:     public hasRelations() {
   24:         return this.relations.keys() !== 0
   25:     }

  Rejected promise returned by test. Reason:

  TypeError {
    message: 'this.relations.keys is not a function',
  }
```
This issue appears fixed with the change in this PR.

Additionally "npm run test" was failing for me with the following error:
```
  × Enhancement compilation must be configured in AVA’s Babel options.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @aerogear/graphql-query-mapper@0.3.0 test: `ava`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @aerogear/graphql-query-mapper@0.3.0 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```


I had to remove the compileEnhancements attribute in the "ava" section of package.json to be able to run the tests. There is some discussion on the issue here - https://github.com/avajs/ava/issues/2376. I'm not sure if you have any issues running tests with npm run test as it currently sits in master branch.




